### PR TITLE
Avoid using redundant pipe for awk read

### DIFF
--- a/input.txt
+++ b/input.txt
@@ -1,3 +1,4 @@
-8.8.8.8 #dns for google
+8.8.8.8 #dns from google
 10.10.10.10 #bogus ip
-1.1.1.1 #dns
+1.1.1.1 #dns from cloudfare
+::1

--- a/practica.sh
+++ b/practica.sh
@@ -6,7 +6,10 @@
 # xargs => takes the input from the previous command and passes it as argument to ping
 # | (pipe) => connects two commands through standard file interface
 
-cat input.txt | awk '{print $1}' | xargs -n 1 ping -c 1
+awk '{print $1}' input.txt | xargs -r -I '{}' \
+  bash -c "echo '{}' | grep -q -e ':' && \
+    ping6 -c 1 '{}' -W 1 || \
+    ping -c 1 '{}' -W 1"
 
 #TODO Dan: Print the first x numbers from Fibonacci in a file
 


### PR DESCRIPTION
Read input file with `awk` directly instead of relying on `cat` and
piping its output to stdin.

While at it, adjust input file comments and:
- add 'no run if empty' for xargs, so it ommits empty input lines;
- add an IPv6 address to input file;
- add ping6 support with a simple input check (if an address contains
  the ':' char, it should be treated as an IPv6 address);
- set ping timeout to 1 second, so we bail fast on non-responsive
  addresses;